### PR TITLE
ci: update circle to use node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:8-browsers
+    - image: circleci/node:10-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,8 +1016,8 @@
     },
     "@types/yauzl": {
       "version": "2.9.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1054,8 +1054,8 @@
     },
     "agent-base": {
       "version": "5.1.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
       "dev": true
     },
     "aggregate-error": {
@@ -1732,8 +1732,8 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "binary-extensions": {
@@ -1745,8 +1745,8 @@
     },
     "bl": {
       "version": "4.0.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha1-UrcekIhRXQYG2d2cx6pI3B+Y5zo=",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -1756,8 +1756,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -1905,8 +1905,8 @@
     },
     "buffer": {
       "version": "5.6.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha1-oxdJ3H2B2E2wir+Te2uMQDP2J4Y=",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -1915,7 +1915,7 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -3529,12 +3529,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
-    "devtools-protocol": {
-      "version": "0.0.767361",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/devtools-protocol/-/devtools-protocol-0.0.767361.tgz",
-      "integrity": "sha1-WXfyVYuE+d829iUBvd24Lzrntms=",
-      "dev": true
-    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -3859,8 +3853,8 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
@@ -3871,8 +3865,8 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3880,8 +3874,8 @@
         },
         "get-stream": {
           "version": "5.1.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -3889,8 +3883,8 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -3979,7 +3973,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -4132,8 +4126,8 @@
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-minipass": {
@@ -5449,8 +5443,8 @@
     },
     "https-proxy-agent": {
       "version": "4.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "dev": true,
       "requires": {
         "agent-base": "5",
@@ -5459,8 +5453,8 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -5468,8 +5462,8 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -5563,8 +5557,8 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "ignore": {
@@ -6936,8 +6930,8 @@
     },
     "mime": {
       "version": "2.4.6",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
       "dev": true
     },
     "mimic-fn": {
@@ -7020,9 +7014,9 @@
       }
     },
     "mitt": {
-      "version": "2.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/mitt/-/mitt-2.0.1.tgz",
-      "integrity": "sha1-nooHW02q6C3ZGqwVWg7OQMp8s5M=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
       "dev": true
     },
     "mixin-deep": {
@@ -7057,8 +7051,8 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "modify-values": {
@@ -7798,14 +7792,14 @@
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "pseudomap": {
@@ -7834,13 +7828,12 @@
       }
     },
     "puppeteer": {
-      "version": "5.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/puppeteer/-/puppeteer-5.1.0.tgz",
-      "integrity": "sha1-57riyqbjoTpiJ1XkwnaJ2YEsOMo=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.0.0.tgz",
+      "integrity": "sha512-JnZcgRQnfowRSJoSHteKU7G9fP/YYGB/juPn8m4jNqtzvR0h8GOoFmdjTBesJFfzhYkPU1FosHXnBVUB++xgaA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.767361",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
@@ -7856,8 +7849,8 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -7865,14 +7858,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -9068,8 +9061,8 @@
     },
     "tar-fs": {
       "version": "2.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha1-0c3RIatGXuDrnM3i01BJ0/Pa8NU=",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
@@ -9080,8 +9073,8 @@
     },
     "tar-stream": {
       "version": "2.1.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha1-HiAiVZIht4ZhYWYPEYJV4g+nnkE=",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
       "dev": true,
       "requires": {
         "bl": "^4.0.1",
@@ -9093,8 +9086,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -9383,8 +9376,8 @@
     },
     "unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha1-sNoExDcTEd93HNwhXofyEwmRrOc=",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -9699,8 +9692,8 @@
     },
     "ws": {
       "version": "7.3.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha1-0FR79n985PEqct/jEmLGjX3FUcg=",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
       "dev": true
     },
     "xdg-basedir": {
@@ -9834,7 +9827,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.1.0",
+    "puppeteer": "^5.0.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",


### PR DESCRIPTION
Ava 3.0 no longer runs on node 8 and needs at least node 10 ([coverage was failing in ci](https://circleci.com/gh/dequelabs/puppeteer-devtools/199))

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
