### PR TITLE
chore: Make axe Linter ignore CHANGELOG.md

### DIFF
--- a/.github/axe-linter.yml
+++ b/.github/axe-linter.yml
@@ -1,0 +1,2 @@
+exclude:
+  - CHANGELOG.md


### PR DESCRIPTION
The CHANGELOG is generated 🤷

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
