### PR TITLE
feat: add ability to get an extension's content script execution context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:12-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key
@@ -25,7 +25,8 @@ jobs:
     steps:
       - checkout
       - <<: *restore_node_modules_cache
-      - run: npm ci
+      # Default to the bundled version of chromium with circleci
+      - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,8 @@
-version: 2.1
-orbs:
-  puppeteer: threetreeslight/puppeteer@0.1.2
+version: 2
 
 defaults: &defaults
   docker:
     - image: circleci/node:12
-      environment:
-        NODE_ENV: development
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:14-browsers
+    - image: circleci/node:10-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          command: |
+            google-chrome --version
       - <<: *restore_node_modules_cache
       - run: npm ci
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             google-chrome --version
       - <<: *restore_node_modules_cache
-      - run: npm ci
+      - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
       - save_cache:
           paths:
             - node_modules
@@ -38,7 +38,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_node_modules_cache
-      - run: npm run coverage
+      - run: PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome npm run coverage
   lint:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:12
+    - image: circleci/node:12-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  puppeteer: threetreeslight/puppeteer@0.1.2
 
 defaults: &defaults
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ orbs:
 defaults: &defaults
   docker:
     - image: circleci/node:12
+      environment:
+        NODE_ENV: development
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
-version: 2
+version: 2.1
+orbs:
+  puppeteer: threetreeslight/puppeteer@0.1.2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:12-browsers
+    - image: circleci/node:12
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key
@@ -25,8 +27,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_node_modules_cache
-      # Default to the bundled version of chromium with circleci
-      - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
+      - run: npm ci
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           command: |
             google-chrome --version
       - <<: *restore_node_modules_cache
+      # Skip the bundled version of chrome; always use the one provided from circle
       - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:12-browsers
+    - image: circleci/node:14-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2.0
+version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:12-browsers
+    - image: circleci/node:latest-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,8 @@
-version: 2.1
-orbs:
-  puppeteer: threetreeslight/puppeteer@0.1.2
+version: 2.0
 
 defaults: &defaults
   docker:
-    - image: circleci/node:10-browsers
+    - image: circleci/node:12-browsers
   working_directory: ~/puppeteer-devtools
 
 npm_cache_key: &npm_cache_key

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note: `devtools` must be enabled, and `headless` mode must be turned off. Chrome
 
 ## Methods
 
-### async getDevtools( page, options? )
+### `async getDevtools( page, options? )`
 
 Returns the underlying Chrome `devtools://` page as a <code>Promise<[Page](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page)></code>.
 
@@ -55,7 +55,7 @@ Returns the underlying Chrome `devtools://` page as a <code>Promise<[Page](https
 - **`options`** - <`object`>
   - **`timeout`** - <`number | null`> Maximum time in milliseconds to wait for the devtools page to become available. Uses puppeteer's default timeout if not set.
 
-### async getDevtoolsPanel( page, options? )
+### `async getDevtoolsPanel( page, options? )`
 
 Returns the underlying Chrome `chrome-extension://` panel as a <code>Promise<[Frame](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-frame)></code>.
 
@@ -64,14 +64,14 @@ Returns the underlying Chrome `chrome-extension://` panel as a <code>Promise<[Fr
   - **`panelName`** - <`string`> The file name of the extension panel to find. A devtools page with `chrome.devtools.panels.create('name', 'icon.png', 'panel.html', (panel) => { ... })` would have `panel.html` as its value.
   - **`timeout`** - <`number | null`> Maximum time in milliseconds to wait for the chrome extension panel to become available. Uses puppeteer's default timeout if not set.
 
-### async setCaptureContentScriptExecutionContexts( page, enable )
+### `async setCaptureContentScriptExecutionContexts( page, enable )`
 
 Activating capture content script execution contexts will allow for the usage of an extension's content script [`ExecutionContext`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#class-executioncontext). This must be activated before a page is navigated.
 
 - **`page`** - <[`Page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page)> Puppeteer page object.
 - **`enable`** - <`boolean`> Enable or disable content script execution context capturing
 
-### async getContentScriptExcecutionContext( page )
+### `async getContentScriptExcecutionContext( page )`
 
 If `setCaptureContentScriptExecutionContexts` has been enabled for a page, this returns the extension's content script [`ExecutionContext`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#class-executioncontext). This will error for pages that the extension does not have permissions for or for extensions that do not have content scripts.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const browser = await puppeteer.launch({
 })
 
 const [page] = await browser.pages()
-await setCaptureContentScriptExecutionContexts(page, true)
+await setCaptureContentScriptExecutionContexts(page)
 
 await page.goto('https://google.com', { waitUntil: 'networkidle0' })
 const panel = await getDevtoolsPanel(page, { panelName: 'panel.html' })
@@ -64,12 +64,11 @@ Returns the underlying Chrome `chrome-extension://` panel as a <code>Promise<[Fr
   - **`panelName`** - <`string`> The file name of the extension panel to find. A devtools page with `chrome.devtools.panels.create('name', 'icon.png', 'panel.html', (panel) => { ... })` would have `panel.html` as its value.
   - **`timeout`** - <`number | null`> Maximum time in milliseconds to wait for the chrome extension panel to become available. Uses puppeteer's default timeout if not set.
 
-### `async setCaptureContentScriptExecutionContexts( page, enable )`
+### `async setCaptureContentScriptExecutionContexts( page )`
 
 Activating capture content script execution contexts will allow for the usage of an extension's content script [`ExecutionContext`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#class-executioncontext). This must be activated before a page is navigated.
 
 - **`page`** - <[`Page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page)> Puppeteer page object.
-- **`enable`** - <`boolean`> Enable or disable content script execution context capturing
 
 ### `async getContentScriptExcecutionContext( page )`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Extended puppeteer methods for getting extension devtools contexts.
 
 ```js
 const puppeteer = require('puppeteer')
-const { getDevtoolsPanel } = require('puppeteer-devtools')
+const {
+  getDevtoolsPanel,
+  setCaptureContentScriptExecutionContexts,
+  getContentScriptExcecutionContext
+} = require('puppeteer-devtools')
 const path = require('path')
 
 const extension = path.resolve('/path/to/extension')
@@ -30,7 +34,13 @@ const browser = await puppeteer.launch({
 })
 
 const [page] = await browser.pages()
+await setCaptureContentScriptExecutionContexts(page, true)
+
+await page.goto('https://google.com', { waitUntil: 'networkidle0' })
 const panel = await getDevtoolsPanel(page, { panelName: 'panel.html' })
+const contentScriptExecutionContext = await getContentScriptExecutionContext(
+  page
+)
 ```
 
 Note: `devtools` must be enabled, and `headless` mode must be turned off. Chrome [does not currently support extensions in headless mode](https://bugs.chromium.org/p/chromium/issues/detail?id=706008).
@@ -54,10 +64,23 @@ Returns the underlying Chrome `chrome-extension://` panel as a <code>Promise<[Fr
   - **`panelName`** - <`string`> The file name of the extension panel to find. A devtools page with `chrome.devtools.panels.create('name', 'icon.png', 'panel.html', (panel) => { ... })` would have `panel.html` as its value.
   - **`timeout`** - <`number | null`> Maximum time in milliseconds to wait for the chrome extension panel to become available. Uses puppeteer's default timeout if not set.
 
+### async setCaptureContentScriptExecutionContexts( page, enable )
+
+Activating capture content script execution contexts will allow for the usage of an extension's content script [`ExecutionContext`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#class-executioncontext). This must be activated before a page is navigated.
+
+- **`page`** - <[`Page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page)> Puppeteer page object.
+- **`enable`** - <`boolean`> Enable or disable content script execution context capturing
+
+### async getContentScriptExcecutionContext( page )
+
+If `setCaptureContentScriptExecutionContexts` has been enabled for a page, this returns the extension's content script [`ExecutionContext`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#class-executioncontext). This will error for pages that the extension does not have permissions for or for extensions that do not have content scripts.
+
+- **`page`** - <[`Page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page)> Puppeteer page object.
+
 ## License
 
 [MPL 2.0](LICENSE)
 
 ## Copyright
 
-Copyright (c) 2019-2020 Deque Systems, Inc.
+Copyright (c) 2019-2021 Deque Systems, Inc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.20.2.tgz",
-      "integrity": "sha512-oSFCtftHSfVx8K9XPdNNYs79Zt4pYJs/0NP78ltuGCB25zS3UNGJSiypBfbhbvRC5Dcsh0k1R5Z0i8HHtqQUPQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.2.tgz",
+      "integrity": "sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1174,22 +1174,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -1213,8 +1210,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "arrgv": {
       "version": "1.0.2",
@@ -1232,8 +1228,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -1252,8 +1247,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ava": {
       "version": "3.10.1",
@@ -1686,7 +1680,6 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1702,7 +1695,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -1712,7 +1704,6 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1722,7 +1713,6 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1732,7 +1722,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1742,9 +1731,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "binary-extensions": {
@@ -1879,7 +1868,6 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -1898,7 +1886,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -1917,18 +1904,18 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -1949,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -2154,7 +2140,6 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -2167,7 +2152,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2293,7 +2277,6 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -2363,8 +2346,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3259,8 +3241,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.4.1",
@@ -3374,7 +3355,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3407,8 +3387,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -3469,7 +3448,6 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -3480,7 +3458,6 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3490,7 +3467,6 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3500,7 +3476,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -3552,6 +3527,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "devtools-protocol": {
+      "version": "0.0.818844",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
       "dev": true
     },
     "diff": {
@@ -3760,7 +3741,6 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -3776,7 +3756,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -3786,7 +3765,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -3798,7 +3776,6 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -3809,7 +3786,6 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -3821,7 +3797,6 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -3838,7 +3813,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -3848,7 +3822,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -3858,7 +3831,6 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3868,7 +3840,6 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3878,7 +3849,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -3900,18 +3870,18 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -4009,7 +3979,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -4030,7 +4000,6 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -4043,7 +4012,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -4120,8 +4088,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -4150,7 +4117,6 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -4214,8 +4180,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4239,15 +4204,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4257,22 +4220,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4393,15 +4353,13 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4418,7 +4376,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4548,8 +4505,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4563,7 +4519,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4700,7 +4655,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4722,7 +4676,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4755,8 +4708,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -5005,8 +4957,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "git-raw-commits": {
       "version": "2.0.0",
@@ -5438,7 +5389,6 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -5450,7 +5400,6 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -5461,7 +5410,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5503,12 +5451,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -5607,9 +5555,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {
@@ -5718,7 +5666,6 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -5728,7 +5675,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5755,8 +5701,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -5778,7 +5723,6 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -5788,7 +5732,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5806,7 +5749,6 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -5817,8 +5759,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5838,8 +5779,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -5895,7 +5835,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -5905,7 +5844,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5941,7 +5879,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
-      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -6007,8 +5944,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -6032,8 +5968,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -6235,8 +6170,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "latest-version": {
       "version": "5.1.0",
@@ -6876,8 +6810,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "map-obj": {
       "version": "2.0.0",
@@ -6890,7 +6823,6 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
-      "optional": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -6979,7 +6911,6 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -6995,12 +6926,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
-    },
-    "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-      "dev": true
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -7058,7 +6983,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -7068,8 +6992,7 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7083,18 +7006,11 @@
         "minipass": "^2.9.0"
       }
     },
-    "mitt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
-      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
-      "dev": true
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -7105,7 +7021,6 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -7137,8 +7052,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -7158,7 +7072,6 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -7189,6 +7102,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
@@ -7381,7 +7300,6 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
-      "optional": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -7393,7 +7311,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -7403,7 +7320,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -7427,7 +7343,6 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -7449,7 +7364,6 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -7655,8 +7569,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -7835,8 +7748,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -7909,16 +7821,16 @@
       }
     },
     "puppeteer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.0.0.tgz",
-      "integrity": "sha512-JnZcgRQnfowRSJoSHteKU7G9fP/YYGB/juPn8m4jNqtzvR0h8GOoFmdjTBesJFfzhYkPU1FosHXnBVUB++xgaA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
+      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
+        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
-        "mitt": "^2.0.1",
+        "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
@@ -7929,12 +7841,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -8133,7 +8045,6 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -8214,15 +8125,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -8273,8 +8182,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "responselike": {
       "version": "1.0.2",
@@ -8299,8 +8207,7 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -8349,7 +8256,6 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -8400,7 +8306,6 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -8413,7 +8318,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -8513,7 +8417,6 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -8530,7 +8433,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -8540,7 +8442,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -8552,7 +8453,6 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -8564,7 +8464,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -8574,7 +8473,6 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -8584,7 +8482,6 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -8594,7 +8491,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -8608,7 +8504,6 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -8618,7 +8513,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8636,7 +8530,6 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -8667,8 +8560,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "spawn-wrap": {
       "version": "1.4.3",
@@ -8741,7 +8633,6 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -8917,7 +8808,6 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -8928,7 +8818,6 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -9164,24 +9053,24 @@
       }
     },
     "tar-fs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
+        "tar-stream": "^2.1.4"
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -9310,7 +9199,6 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -9320,7 +9208,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -9338,7 +9225,6 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -9351,7 +9237,6 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -9525,7 +9410,6 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -9547,7 +9431,6 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -9558,7 +9441,6 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -9570,7 +9452,6 @@
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -9581,8 +9462,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9670,8 +9550,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -9686,8 +9565,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -9806,9 +9684,9 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
       "dev": true
     },
     "xdg-basedir": {
@@ -9942,7 +9820,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3530,9 +3530,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.809251",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.809251.tgz",
-      "integrity": "sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==",
+      "version": "0.0.818844",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
       "dev": true
     },
     "diff": {
@@ -7821,13 +7821,13 @@
       }
     },
     "puppeteer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.0.tgz",
-      "integrity": "sha512-LgTqVW2ClEP4XGAT64FLQ0QWVhdNSRwJp9HfMFVfoJlZHGQu3HUbuBhR1hBow3DXZH1K3b/WfHxt1n8hr2uayw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
+      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.809251",
+        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "node-fetch": "^2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3529,6 +3529,12 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "devtools-protocol": {
+      "version": "0.0.818844",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "dev": true
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -6921,12 +6927,6 @@
         "to-regex": "^3.0.2"
       }
     },
-    "mime": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
-      "dev": true
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7005,12 +7005,6 @@
       "requires": {
         "minipass": "^2.9.0"
       }
-    },
-    "mitt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
-      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
-      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7108,6 +7102,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
@@ -7821,16 +7821,16 @@
       }
     },
     "puppeteer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.0.0.tgz",
-      "integrity": "sha512-JnZcgRQnfowRSJoSHteKU7G9fP/YYGB/juPn8m4jNqtzvR0h8GOoFmdjTBesJFfzhYkPU1FosHXnBVUB++xgaA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
+      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
+        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
-        "mitt": "^2.0.1",
+        "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3530,9 +3530,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "version": "0.0.767361",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.767361.tgz",
+      "integrity": "sha512-ziRTdhEVQ9jEwedaUaXZ7kl9w9TF/7A3SXQ0XuqrJB+hMS62POHZUWTbumDN2ehRTfvWqTPc2Jw4gUl/jggmHA==",
       "dev": true
     },
     "diff": {
@@ -6927,6 +6927,12 @@
         "to-regex": "^3.0.2"
       }
     },
+    "mime": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7102,12 +7108,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
@@ -7821,16 +7821,16 @@
       }
     },
     "puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.2.0.tgz",
+      "integrity": "sha512-Hru70mFT+dts5W3l1MVg46EfJiWE63qjmXlDvC2kkCeEzLgt6KrwEkDJcJKKzERTvy9xXhOvjyGNx36fd78mVQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
+        "devtools-protocol": "0.0.767361",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
+        "mime": "^2.0.3",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3529,12 +3529,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
-    "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
-      "dev": true
-    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -6927,6 +6921,12 @@
         "to-regex": "^3.0.2"
       }
     },
+    "mime": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7005,6 +7005,12 @@
       "requires": {
         "minipass": "^2.9.0"
       }
+    },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7102,12 +7108,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
@@ -7821,16 +7821,16 @@
       }
     },
     "puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.0.0.tgz",
+      "integrity": "sha512-JnZcgRQnfowRSJoSHteKU7G9fP/YYGB/juPn8m4jNqtzvR0h8GOoFmdjTBesJFfzhYkPU1FosHXnBVUB++xgaA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
+        "mime": "^2.0.3",
+        "mitt": "^2.0.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1915,7 +1915,7 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -3530,9 +3530,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "version": "0.0.809251",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.809251.tgz",
+      "integrity": "sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==",
       "dev": true
     },
     "diff": {
@@ -3979,7 +3979,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -7821,13 +7821,13 @@
       }
     },
     "puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.0.tgz",
+      "integrity": "sha512-LgTqVW2ClEP4XGAT64FLQ0QWVhdNSRwJp9HfMFVfoJlZHGQu3HUbuBhR1hBow3DXZH1K3b/WfHxt1n8hr2uayw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
+        "devtools-protocol": "0.0.809251",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "node-fetch": "^2.6.1",
@@ -9820,7 +9820,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3530,9 +3530,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.767361",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.767361.tgz",
-      "integrity": "sha512-ziRTdhEVQ9jEwedaUaXZ7kl9w9TF/7A3SXQ0XuqrJB+hMS62POHZUWTbumDN2ehRTfvWqTPc2Jw4gUl/jggmHA==",
+      "version": "0.0.809251",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.809251.tgz",
+      "integrity": "sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==",
       "dev": true
     },
     "diff": {
@@ -6927,12 +6927,6 @@
         "to-regex": "^3.0.2"
       }
     },
-    "mime": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
-      "dev": true
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7108,6 +7102,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-releases": {
@@ -7821,16 +7821,16 @@
       }
     },
     "puppeteer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.2.0.tgz",
-      "integrity": "sha512-Hru70mFT+dts5W3l1MVg46EfJiWE63qjmXlDvC2kkCeEzLgt6KrwEkDJcJKKzERTvy9xXhOvjyGNx36fd78mVQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.0.tgz",
+      "integrity": "sha512-LgTqVW2ClEP4XGAT64FLQ0QWVhdNSRwJp9HfMFVfoJlZHGQu3HUbuBhR1hBow3DXZH1K3b/WfHxt1n8hr2uayw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.767361",
+        "devtools-protocol": "0.0.809251",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
+        "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.0.0",
+    "puppeteer": "^5.5.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^5.0.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "@babel/core": "^7.7.2",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-typescript": "^7.7.2",
-    "@types/puppeteer": "^1.20.2",
+    "@types/puppeteer": "^5.4.2",
     "ava": "^3.10.1",
     "husky": "^3.1.0",
     "lint-staged": "^9.4.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.0.0",
+    "puppeteer": "^5.5.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",
@@ -51,6 +51,9 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "puppeteer": ">= 5.2.0"
+  },
   "prettier": {
     "singleQuote": true,
     "arrowParens": "avoid",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.2.0",
+    "puppeteer": "^5.4.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.4.0",
+    "puppeteer": "^5.5.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^5.2.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "prettier": "^1.19.1",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^5.4.0",
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.1",
     "ts-node": "^8.5.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,9 @@ import { Page, Frame, Target, errors } from 'puppeteer'
 import {
   DOMWorld,
   ExecutionContext,
-  Protocol,
+  ExecutionContextDescription,
   CDPSession
 } from './puppeteer-adapter'
-
-type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
 
 const devtoolsUrl = 'devtools://'
 const extensionUrl = 'chrome-extension://'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,16 +10,14 @@
  * code.
  */
 import { Page, Frame, Target, errors } from 'puppeteer'
-// import {
-//   DOMWorld,
-//   ExecutionContext,
-//   Protocol,
-//   CDPSession
-// } from './puppeteer-adapter'
+import {
+  DOMWorld,
+  ExecutionContext,
+  Protocol,
+  CDPSession
+} from './puppeteer-adapter'
 
-// type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
-type ExecutionContext = any
-type ExecutionContextDescription = any
+type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
 
 const devtoolsUrl = 'devtools://'
 const extensionUrl = 'chrome-extension://'
@@ -152,35 +150,37 @@ async function setCaptureContentScriptExecutionContexts(
   page: Page,
   enable: boolean
 ) {
-  // const client = await setCaptureExecutionContexts(page, enable, context =>
-  //   context.origin.startsWith(extensionUrl)
-  // )
-  // client.on(
-  //   'executionContextCreated',
-  //   (context: ExecutionContextDescription) => {
-  //     contentScriptExecutionContexts.set(page, context)
-  //   }
-  // )
+  const client = await setCaptureExecutionContexts(page, enable, context =>
+    context.origin.startsWith(extensionUrl)
+  )
+  client.on(
+    'executionContextCreated',
+    (context: ExecutionContextDescription) => {
+      contentScriptExecutionContexts.set(page, context)
+    }
+  )
 }
 
 async function getContentScriptExcecutionContext(
   page: Page
 ): Promise<ExecutionContext> {
-  // const contentScriptExecutionContext = contentScriptExecutionContexts.get(page)
-  // if (!contentScriptExecutionContext) {
-  //   throw new Error(
-  //     `Could not find "${extensionUrl}" content script execution context`
-  //   )
-  // }
-  // const client = await page.target().createCDPSession()
-  // return new ExecutionContext(
-  //   client as CDPSession,
-  //   contentScriptExecutionContext,
-  //   // DOMWorld is used to return the associated frame. Extension execution
-  //   // contexts don't have an associated frame, so this can be safely ignored
-  //   // see: https://github.com/puppeteer/puppeteer/blob/9dd1aa302d719bef29e67c33f1f4717f1c0e2b79/src/common/ExecutionContext.ts#L73-L84
-  //   (null as unknown) as DOMWorld
-  // )
+  const contentScriptExecutionContext = contentScriptExecutionContexts.get(page)
+
+  if (!contentScriptExecutionContext) {
+    throw new Error(
+      `Could not find "${extensionUrl}" content script execution context`
+    )
+  }
+
+  const client = await page.target().createCDPSession()
+  return new ExecutionContext(
+    client as CDPSession,
+    contentScriptExecutionContext,
+    // DOMWorld is used to return the associated frame. Extension execution
+    // contexts don't have an associated frame, so this can be safely ignored
+    // see: https://github.com/puppeteer/puppeteer/blob/9dd1aa302d719bef29e67c33f1f4717f1c0e2b79/src/common/ExecutionContext.ts#L73-L84
+    (null as unknown) as DOMWorld
+  )
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,14 +10,16 @@
  * code.
  */
 import { Page, Frame, Target, errors } from 'puppeteer'
-import {
-  DOMWorld,
-  ExecutionContext,
-  Protocol,
-  CDPSession
-} from './puppeteer-adapter'
+// import {
+//   DOMWorld,
+//   ExecutionContext,
+//   Protocol,
+//   CDPSession
+// } from './puppeteer-adapter'
 
-type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
+// type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
+type ExecutionContext = any
+type ExecutionContextDescription = any
 
 const devtoolsUrl = 'devtools://'
 const extensionUrl = 'chrome-extension://'
@@ -150,37 +152,35 @@ async function setCaptureContentScriptExecutionContexts(
   page: Page,
   enable: boolean
 ) {
-  const client = await setCaptureExecutionContexts(page, enable, context =>
-    context.origin.startsWith(extensionUrl)
-  )
-  client.on(
-    'executionContextCreated',
-    (context: ExecutionContextDescription) => {
-      contentScriptExecutionContexts.set(page, context)
-    }
-  )
+  // const client = await setCaptureExecutionContexts(page, enable, context =>
+  //   context.origin.startsWith(extensionUrl)
+  // )
+  // client.on(
+  //   'executionContextCreated',
+  //   (context: ExecutionContextDescription) => {
+  //     contentScriptExecutionContexts.set(page, context)
+  //   }
+  // )
 }
 
 async function getContentScriptExcecutionContext(
   page: Page
 ): Promise<ExecutionContext> {
-  const contentScriptExecutionContext = contentScriptExecutionContexts.get(page)
-
-  if (!contentScriptExecutionContext) {
-    throw new Error(
-      `Could not find "${extensionUrl}" content script execution context`
-    )
-  }
-
-  const client = await page.target().createCDPSession()
-  return new ExecutionContext(
-    client as CDPSession,
-    contentScriptExecutionContext,
-    // DOMWorld is used to return the associated frame. Extension execution
-    // contexts don't have an associated frame, so this can be safely ignored
-    // see: https://github.com/puppeteer/puppeteer/blob/9dd1aa302d719bef29e67c33f1f4717f1c0e2b79/src/common/ExecutionContext.ts#L73-L84
-    (null as unknown) as DOMWorld
-  )
+  // const contentScriptExecutionContext = contentScriptExecutionContexts.get(page)
+  // if (!contentScriptExecutionContext) {
+  //   throw new Error(
+  //     `Could not find "${extensionUrl}" content script execution context`
+  //   )
+  // }
+  // const client = await page.target().createCDPSession()
+  // return new ExecutionContext(
+  //   client as CDPSession,
+  //   contentScriptExecutionContext,
+  //   // DOMWorld is used to return the associated frame. Extension execution
+  //   // contexts don't have an associated frame, so this can be safely ignored
+  //   // see: https://github.com/puppeteer/puppeteer/blob/9dd1aa302d719bef29e67c33f1f4717f1c0e2b79/src/common/ExecutionContext.ts#L73-L84
+  //   (null as unknown) as DOMWorld
+  // )
 }
 
 export {

--- a/src/puppeteer-adapter.ts
+++ b/src/puppeteer-adapter.ts
@@ -1,7 +1,7 @@
-import { DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld'
-import { ExecutionContext } from 'puppeteer/lib/cjs/puppeteer/common/ExecutionContext'
-import Protocol from 'devtools-protocol'
-import { CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection'
+import { DOMWorld } from 'puppeteer/lib/cjs/common/DOMWorld'
+import { ExecutionContext } from 'puppeteer/lib/cjs/common/ExecutionContext'
+// import Protocol from 'devtools-protocol'
+import { CDPSession } from 'puppeteer/lib/cjs/common/Connection'
 
-export type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
-export { DOMWorld, Protocol, CDPSession, ExecutionContext }
+export type ExecutionContextDescription = any //Protocol.Runtime.ExecutionContextDescription
+export { DOMWorld, CDPSession, ExecutionContext }

--- a/src/puppeteer-adapter.ts
+++ b/src/puppeteer-adapter.ts
@@ -1,0 +1,7 @@
+import { DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld'
+import { ExecutionContext } from 'puppeteer/lib/cjs/puppeteer/common/ExecutionContext'
+import Protocol from 'devtools-protocol'
+import { CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection'
+
+export type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
+export { DOMWorld, Protocol, CDPSession, ExecutionContext }

--- a/src/puppeteer-adapter.ts
+++ b/src/puppeteer-adapter.ts
@@ -1,7 +1,7 @@
-import { DOMWorld } from 'puppeteer/lib/cjs/common/DOMWorld'
-import { ExecutionContext } from 'puppeteer/lib/cjs/common/ExecutionContext'
-// import Protocol from 'devtools-protocol'
-import { CDPSession } from 'puppeteer/lib/cjs/common/Connection'
+import { DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld'
+import { ExecutionContext } from 'puppeteer/lib/cjs/puppeteer/common/ExecutionContext'
+import Protocol from 'devtools-protocol'
+import { CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection'
 
-export type ExecutionContextDescription = any //Protocol.Runtime.ExecutionContextDescription
+export type ExecutionContextDescription = Protocol.Runtime.ExecutionContextDescription
 export { DOMWorld, CDPSession, ExecutionContext }

--- a/test/extension/content.js
+++ b/test/extension/content.js
@@ -1,0 +1,3 @@
+(() => {
+  window.extension_content_script = true;
+})()

--- a/test/extension/manifest.json
+++ b/test/extension/manifest.json
@@ -4,6 +4,14 @@
   "description": "Test Chrome Extension",
   "version": "1.2.3",
   "devtools_page": "devtools.html",
+  "content_scripts": [
+    {
+      "matches": ["*://testpage.test/"],
+      "js": ["content.js"],
+      "all_frames": true,
+      "run_at": "document_start"
+    }
+  ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "web_accessible_resources": ["page.html"]
 }

--- a/test/extension/manifest.json
+++ b/test/extension/manifest.json
@@ -6,7 +6,7 @@
   "devtools_page": "devtools.html",
   "content_scripts": [
     {
-      "matches": ["*://testpage.test/"],
+      "matches": ["*://testpage.test/", "*://testpage.test/anotherpage"],
       "js": ["content.js"],
       "all_frames": true,
       "run_at": "document_start"

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Puppeteer Devtools Test Fixture Page</title>
+  </head>
+  <body>
+    <main>
+      <h1>Hello</h1>
+    </main>
+  </body>
+</html>

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -22,3 +22,9 @@ test('puppeteer target should have internal _targetInfo property', async t => {
   t.assert(typeof anyTarget._targetInfo === 'object')
   t.assert(anyTarget._targetInfo.hasOwnProperty('type'))
 })
+
+test('puppeteer should have internal ExecutionContext module', async t => {
+  t.notThrows(() => {
+    require('puppeteer/lib/cjs/puppeteer/common/ExecutionContext')
+  })
+})

--- a/test/test.ts
+++ b/test/test.ts
@@ -21,7 +21,8 @@ test.beforeEach(async t => {
     const browser = await puppeteer.launch({
       args: [
         `--disable-extensions-except=${pathToExtension}`,
-        `--load-extension=${pathToExtension}`
+        `--load-extension=${pathToExtension}`,
+        ...[process.env.CI ? '--no-sandbox' : '']
       ],
       defaultViewport: null,
       devtools: true,

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,40 +15,44 @@ const test = testFn as TestInterface<{
 }>
 
 test.beforeEach(async t => {
-  const pathToExtension = path.resolve(__dirname, 'extension')
+  try {
+    const pathToExtension = path.resolve(__dirname, 'extension')
 
-  const browser = await puppeteer.launch({
-    args: [
-      `--disable-extensions-except=${pathToExtension}`,
-      `--load-extension=${pathToExtension}`,
-      ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
-    ],
-    defaultViewport: null,
-    devtools: true,
-    headless: false
-  })
+    const browser = await puppeteer.launch({
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
+      ],
+      defaultViewport: null,
+      devtools: true,
+      headless: false
+    })
 
-  const [page] = await browser.pages()
+    const [page] = await browser.pages()
 
-  // Respond to https://testpage urls with a fixed fixture page
-  await page.setRequestInterception(true)
-  page.on('request', async request => {
-    if (request.url().startsWith('https://testpage')) {
-      const body = fs.readFileSync(
-        path.resolve(__dirname, 'fixtures/index.html')
-      )
-      return request.respond({
-        body,
-        contentType: 'text/html',
-        status: 200
-      })
+    // Respond to https://testpage urls with a fixed fixture page
+    await page.setRequestInterception(true)
+    page.on('request', async request => {
+      if (request.url().startsWith('https://testpage')) {
+        const body = fs.readFileSync(
+          path.resolve(__dirname, 'fixtures/index.html')
+        )
+        return request.respond({
+          body,
+          contentType: 'text/html',
+          status: 200
+        })
+      }
+      return request.continue()
+    })
+
+    t.context = {
+      browser,
+      page
     }
-    return request.continue()
-  })
-
-  t.context = {
-    browser,
-    page
+  } catch (ex) {
+    console.log(`Did not launch browser: ${ex.message}`)
   }
 })
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,7 +22,7 @@ test.beforeEach(async t => {
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
-        ...[process.env.CI ? '--no-sandbox' : '']
+        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
       ],
       defaultViewport: null,
       devtools: true,

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,7 +22,13 @@ test.beforeEach(async t => {
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
-        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
+        ...(process.env.CI
+          ? [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-features=VizDisplayCompositor'
+            ]
+          : [])
       ],
       defaultViewport: null,
       devtools: true,

--- a/test/test.ts
+++ b/test/test.ts
@@ -32,20 +32,20 @@ test.beforeEach(async t => {
     const [page] = await browser.pages()
 
     // Respond to https://testpage urls with a fixed fixture page
-    // await page.setRequestInterception(true)
-    // page.on('request', async request => {
-    //   if (request.url().startsWith('https://testpage')) {
-    //     const body = fs.readFileSync(
-    //       path.resolve(__dirname, 'fixtures/index.html')
-    //     )
-    //     return request.respond({
-    //       body,
-    //       contentType: 'text/html',
-    //       status: 200
-    //     })
-    //   }
-    //   return request.continue()
-    // })
+    await page.setRequestInterception(true)
+    page.on('request', async request => {
+      if (request.url().startsWith('http://testpage')) {
+        const body = fs.readFileSync(
+          path.resolve(__dirname, 'fixtures/index.html')
+        )
+        return request.respond({
+          body,
+          contentType: 'text/html',
+          status: 200
+        })
+      }
+      return request.continue()
+    })
 
     t.context = {
       browser,
@@ -82,7 +82,7 @@ test.serial(
   async t => {
     const { page } = t.context
     await setCaptureContentScriptExecutionContexts(page, true)
-    await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
+    await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
     const contentExecutionContext = await getContentScriptExcecutionContext(
       page
     )
@@ -101,7 +101,7 @@ test.serial(
   'should throw error when unable to find content script execution context',
   async t => {
     const { page } = t.context
-    await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
+    await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
     await t.throwsAsync(
       async () => await getContentScriptExcecutionContext(page)
     )
@@ -113,7 +113,7 @@ test.serial(
   async t => {
     const { page } = t.context
     await setCaptureContentScriptExecutionContexts(page, true)
-    await page.goto('https://testpage.test/that/does/not/have/permission', {
+    await page.goto('http://testpage.test/that/does/not/have/permission', {
       waitUntil: 'networkidle2'
     })
     await t.throwsAsync(

--- a/test/test.ts
+++ b/test/test.ts
@@ -30,7 +30,7 @@ test.beforeEach(async t => {
 
     const [page] = await browser.pages()
 
-    // Respond to https://testpage urls with a fixed fixture page
+    // Respond to http://testpage urls with a set fixture page
     await page.setRequestInterception(true)
     page.on('request', async request => {
       if (request.url().startsWith('http://testpage')) {
@@ -78,7 +78,7 @@ test('should return devtools panel', async t => {
 
 test('should return extension content script execution context', async t => {
   const { page } = t.context
-  await setCaptureContentScriptExecutionContexts(page, true)
+  await setCaptureContentScriptExecutionContexts(page)
   await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
   const contentExecutionContext = await getContentScriptExcecutionContext(page)
   const mainFrameContext = await page.evaluate(
@@ -99,7 +99,7 @@ test('should throw error when unable to find content script execution context', 
 
 test('should throw error when unable to find content script execution context on page without permissions', async t => {
   const { page } = t.context
-  await setCaptureContentScriptExecutionContexts(page, true)
+  await setCaptureContentScriptExecutionContexts(page)
   await page.goto('http://testpage.test/that/does/not/have/permission', {
     waitUntil: 'networkidle2'
   })

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,13 +22,7 @@ test.beforeEach(async t => {
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
-        ...(process.env.CI
-          ? [
-              '--no-sandbox',
-              '--disable-setuid-sandbox',
-              '--disable-features=VizDisplayCompositor'
-            ]
-          : [])
+        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
       ],
       defaultViewport: null,
       devtools: true,

--- a/test/test.ts
+++ b/test/test.ts
@@ -21,8 +21,8 @@ test.beforeEach(async t => {
     const browser = await puppeteer.launch({
       args: [
         `--disable-extensions-except=${pathToExtension}`,
-        `--load-extension=${pathToExtension}`,
-        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
+        `--load-extension=${pathToExtension}`
+        // ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
       ],
       defaultViewport: null,
       devtools: true,
@@ -32,20 +32,20 @@ test.beforeEach(async t => {
     const [page] = await browser.pages()
 
     // Respond to https://testpage urls with a fixed fixture page
-    await page.setRequestInterception(true)
-    page.on('request', async request => {
-      if (request.url().startsWith('https://testpage')) {
-        const body = fs.readFileSync(
-          path.resolve(__dirname, 'fixtures/index.html')
-        )
-        return request.respond({
-          body,
-          contentType: 'text/html',
-          status: 200
-        })
-      }
-      return request.continue()
-    })
+    // await page.setRequestInterception(true)
+    // page.on('request', async request => {
+    //   if (request.url().startsWith('https://testpage')) {
+    //     const body = fs.readFileSync(
+    //       path.resolve(__dirname, 'fixtures/index.html')
+    //     )
+    //     return request.respond({
+    //       body,
+    //       contentType: 'text/html',
+    //       status: 200
+    //     })
+    //   }
+    //   return request.continue()
+    // })
 
     t.context = {
       browser,

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,44 +15,40 @@ const test = testFn as TestInterface<{
 }>
 
 test.beforeEach(async t => {
-  try {
-    const pathToExtension = path.resolve(__dirname, 'extension')
+  const pathToExtension = path.resolve(__dirname, 'extension')
 
-    const browser = await puppeteer.launch({
-      args: [
-        `--disable-extensions-except=${pathToExtension}`,
-        `--load-extension=${pathToExtension}`,
-        ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
-      ],
-      defaultViewport: null,
-      devtools: true,
-      headless: false
-    })
+  const browser = await puppeteer.launch({
+    args: [
+      `--disable-extensions-except=${pathToExtension}`,
+      `--load-extension=${pathToExtension}`,
+      ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
+    ],
+    defaultViewport: null,
+    devtools: true,
+    headless: false
+  })
 
-    const [page] = await browser.pages()
+  const [page] = await browser.pages()
 
-    // Respond to https://testpage urls with a fixed fixture page
-    await page.setRequestInterception(true)
-    page.on('request', async request => {
-      if (request.url().startsWith('https://testpage')) {
-        const body = fs.readFileSync(
-          path.resolve(__dirname, 'fixtures/index.html')
-        )
-        return request.respond({
-          body,
-          contentType: 'text/html',
-          status: 200
-        })
-      }
-      return request.continue()
-    })
-
-    t.context = {
-      browser,
-      page
+  // Respond to https://testpage urls with a fixed fixture page
+  await page.setRequestInterception(true)
+  page.on('request', async request => {
+    if (request.url().startsWith('https://testpage')) {
+      const body = fs.readFileSync(
+        path.resolve(__dirname, 'fixtures/index.html')
+      )
+      return request.respond({
+        body,
+        contentType: 'text/html',
+        status: 200
+      })
     }
-  } catch (ex) {
-    console.log(ex)
+    return request.continue()
+  })
+
+  t.context = {
+    browser,
+    page
   }
 })
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,7 +22,6 @@ test.beforeEach(async t => {
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`
-        // ...(process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [])
       ],
       defaultViewport: null,
       devtools: true,
@@ -63,13 +62,13 @@ test.afterEach.always(async t => {
   }
 })
 
-test.serial('should return devtools page', async t => {
+test('should return devtools page', async t => {
   const { page } = t.context
   const devtools = await getDevtools(page)
   t.regex(await devtools.url(), /^devtools:\/\//)
 })
 
-test.serial('should return devtools panel', async t => {
+test('should return devtools panel', async t => {
   const { page } = t.context
   const devtools = await getDevtoolsPanel(page)
   const body = await devtools.$('body')
@@ -77,57 +76,39 @@ test.serial('should return devtools panel', async t => {
   t.is(textContent.trim(), 'devtools panel')
 })
 
-test.serial(
-  'should return extension content script execution context',
-  async t => {
-    const { page } = t.context
-    await setCaptureContentScriptExecutionContexts(page, true)
-    await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
-    const contentExecutionContext = await getContentScriptExcecutionContext(
-      page
-    )
-    const mainFrameContext = await page.evaluate(
-      () => (window as any).extension_content_script
-    )
-    const contentContext = await contentExecutionContext.evaluate(
-      () => (window as any).extension_content_script
-    )
-    t.is(typeof mainFrameContext, 'undefined')
-    t.truthy(contentContext)
-  }
-)
+test('should return extension content script execution context', async t => {
+  const { page } = t.context
+  await setCaptureContentScriptExecutionContexts(page, true)
+  await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
+  const contentExecutionContext = await getContentScriptExcecutionContext(page)
+  const mainFrameContext = await page.evaluate(
+    () => (window as any).extension_content_script
+  )
+  const contentContext = await contentExecutionContext.evaluate(
+    () => (window as any).extension_content_script
+  )
+  t.is(typeof mainFrameContext, 'undefined')
+  t.truthy(contentContext)
+})
 
-test.serial(
-  'should throw error when unable to find content script execution context',
-  async t => {
-    const { page } = t.context
-    await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
-    await t.throwsAsync(
-      async () => await getContentScriptExcecutionContext(page)
-    )
-  }
-)
+test('should throw error when unable to find content script execution context', async t => {
+  const { page } = t.context
+  await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
+  await t.throwsAsync(async () => await getContentScriptExcecutionContext(page))
+})
 
-test.serial(
-  'should throw error when unable to find content script execution context on page without permissions',
-  async t => {
-    const { page } = t.context
-    await setCaptureContentScriptExecutionContexts(page, true)
-    await page.goto('http://testpage.test/that/does/not/have/permission', {
-      waitUntil: 'networkidle2'
-    })
-    await t.throwsAsync(
-      async () => await getContentScriptExcecutionContext(page)
-    )
-  }
-)
+test('should throw error when unable to find content script execution context on page without permissions', async t => {
+  const { page } = t.context
+  await setCaptureContentScriptExecutionContexts(page, true)
+  await page.goto('http://testpage.test/that/does/not/have/permission', {
+    waitUntil: 'networkidle2'
+  })
+  await t.throwsAsync(async () => await getContentScriptExcecutionContext(page))
+})
 
-test.serial(
-  'should throw error when unable to find devtools panel',
-  async t => {
-    const { page } = t.context
-    await t.throwsAsync(async () =>
-      getDevtoolsPanel(page, { panelName: 'foo.html', timeout: 500 })
-    )
-  }
-)
+test('should throw error when unable to find devtools panel', async t => {
+  const { page } = t.context
+  await t.throwsAsync(async () =>
+    getDevtoolsPanel(page, { panelName: 'foo.html', timeout: 500 })
+  )
+})

--- a/test/test.ts
+++ b/test/test.ts
@@ -63,13 +63,13 @@ test.afterEach.always(async t => {
   }
 })
 
-test('should return devtools page', async t => {
+test.serial('should return devtools page', async t => {
   const { page } = t.context
   const devtools = await getDevtools(page)
   t.regex(await devtools.url(), /^devtools:\/\//)
 })
 
-test('should return devtools panel', async t => {
+test.serial('should return devtools panel', async t => {
   const { page } = t.context
   const devtools = await getDevtoolsPanel(page)
   const body = await devtools.$('body')
@@ -77,39 +77,57 @@ test('should return devtools panel', async t => {
   t.is(textContent.trim(), 'devtools panel')
 })
 
-test('should return extension content script execution context', async t => {
-  const { page } = t.context
-  await setCaptureContentScriptExecutionContexts(page, true)
-  await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
-  const contentExecutionContext = await getContentScriptExcecutionContext(page)
-  const mainFrameContext = await page.evaluate(
-    () => (window as any).extension_content_script
-  )
-  const contentContext = await contentExecutionContext.evaluate(
-    () => (window as any).extension_content_script
-  )
-  t.is(typeof mainFrameContext, 'undefined')
-  t.truthy(contentContext)
-})
+test.serial(
+  'should return extension content script execution context',
+  async t => {
+    const { page } = t.context
+    await setCaptureContentScriptExecutionContexts(page, true)
+    await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
+    const contentExecutionContext = await getContentScriptExcecutionContext(
+      page
+    )
+    const mainFrameContext = await page.evaluate(
+      () => (window as any).extension_content_script
+    )
+    const contentContext = await contentExecutionContext.evaluate(
+      () => (window as any).extension_content_script
+    )
+    t.is(typeof mainFrameContext, 'undefined')
+    t.truthy(contentContext)
+  }
+)
 
-test('should throw error when unable to find content script execution context', async t => {
-  const { page } = t.context
-  await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
-  await t.throwsAsync(async () => await getContentScriptExcecutionContext(page))
-})
+test.serial(
+  'should throw error when unable to find content script execution context',
+  async t => {
+    const { page } = t.context
+    await page.goto('https://testpage.test', { waitUntil: 'networkidle2' })
+    await t.throwsAsync(
+      async () => await getContentScriptExcecutionContext(page)
+    )
+  }
+)
 
-test('should throw error when unable to find content script execution context on page without permissions', async t => {
-  const { page } = t.context
-  await setCaptureContentScriptExecutionContexts(page, true)
-  await page.goto('https://testpage.test/that/does/not/have/permission', {
-    waitUntil: 'networkidle2'
-  })
-  await t.throwsAsync(async () => await getContentScriptExcecutionContext(page))
-})
+test.serial(
+  'should throw error when unable to find content script execution context on page without permissions',
+  async t => {
+    const { page } = t.context
+    await setCaptureContentScriptExecutionContexts(page, true)
+    await page.goto('https://testpage.test/that/does/not/have/permission', {
+      waitUntil: 'networkidle2'
+    })
+    await t.throwsAsync(
+      async () => await getContentScriptExcecutionContext(page)
+    )
+  }
+)
 
-test('should throw error when unable to find devtools panel', async t => {
-  const { page } = t.context
-  await t.throwsAsync(async () =>
-    getDevtoolsPanel(page, { panelName: 'foo.html', timeout: 500 })
-  )
-})
+test.serial(
+  'should throw error when unable to find devtools panel',
+  async t => {
+    const { page } = t.context
+    await t.throwsAsync(async () =>
+      getDevtoolsPanel(page, { panelName: 'foo.html', timeout: 500 })
+    )
+  }
+)


### PR DESCRIPTION
BREAKING CHANGE:
This functionality depends on newer versions of puppeteer (> 5.1.0)

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
