### PR TITLE
fix: only return the execution context for the top most frame

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,8 +134,11 @@ async function setCaptureExecutionContexts(
 }
 
 async function setCaptureContentScriptExecutionContexts(page: Page) {
-  await setCaptureExecutionContexts(page, context =>
-    context.origin.startsWith(extensionUrl)
+  await setCaptureExecutionContexts(
+    page,
+    context =>
+      context.origin.startsWith(extensionUrl) &&
+      (page.mainFrame() as any)._id === context.auxData.frameId
   )
 }
 

--- a/test/extension/manifest.json
+++ b/test/extension/manifest.json
@@ -6,7 +6,7 @@
   "devtools_page": "devtools.html",
   "content_scripts": [
     {
-      "matches": ["*://testpage.test/", "*://testpage.test/anotherpage"],
+      "matches": ["*://testpage.test/", "*://testpage.test/frame"],
       "js": ["content.js"],
       "all_frames": true,
       "run_at": "document_start"

--- a/test/fixtures/frame.html
+++ b/test/fixtures/frame.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Puppeteer Devtools Test Fixture Frame</title>
+  </head>
+  <body>
+    <main>
+      <h1>Inner Frame</h1>
+    </main>
+  </body>
+</html>

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -6,6 +6,7 @@
   <body>
     <main>
       <h1>Hello</h1>
+      <iframe src="/frame"></iframe>
     </main>
   </body>
 </html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -33,6 +33,16 @@ test.beforeEach(async t => {
     // Respond to http://testpage urls with a set fixture page
     await page.setRequestInterception(true)
     page.on('request', async request => {
+      if (request.url() === 'http://testpage.test/frame') {
+        const body = fs.readFileSync(
+          path.resolve(__dirname, 'fixtures/frame.html')
+        )
+        return request.respond({
+          body,
+          contentType: 'text/html',
+          status: 200
+        })
+      }
       if (request.url().startsWith('http://testpage')) {
         const body = fs.readFileSync(
           path.resolve(__dirname, 'fixtures/index.html')


### PR DESCRIPTION
fixes #35 