### PR TITLE
fix: correct puppeteer imports

### DIFF
--- a/src/puppeteer-adapter.ts
+++ b/src/puppeteer-adapter.ts
@@ -1,7 +1,7 @@
-import { type DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld'
+import { DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld.js'
 import { ExecutionContext } from 'puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js'
 import Protocol from 'devtools-protocol'
-import { type CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection'
+import { CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection.js'
 
 export type ExecutionContextDescription =
   Protocol.Runtime.ExecutionContextDescription

--- a/src/puppeteer-adapter.ts
+++ b/src/puppeteer-adapter.ts
@@ -1,7 +1,7 @@
-import { DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld.js'
+import { type DOMWorld } from 'puppeteer/lib/cjs/puppeteer/common/DOMWorld.js'
 import { ExecutionContext } from 'puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js'
 import Protocol from 'devtools-protocol'
-import { CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection.js'
+import { type CDPSession } from 'puppeteer/lib/cjs/puppeteer/common/Connection.js'
 
 export type ExecutionContextDescription =
   Protocol.Runtime.ExecutionContextDescription


### PR DESCRIPTION
Ref: https://github.com/dequelabs/puppeteer-devtools/issues/67

Fixes:
```
  Error: Cannot find module '/Users/trevorhuey/code/axe-extension/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld'
```