### PR TITLE
feat: support changes implemented in devtools frontend api in newer versions of chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           name: "test-chrome-<< matrix.chrome-version >>"
           matrix:
             parameters:
-              chrome-version: ["latest", "102.0.5005.61"]
+              chrome-version: ["latest", "119.0.6045.159"]
           requires:
             - dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
         type: string
         default: "latest"
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-chrome:
           chrome-version: << parameters.chrome-version >>
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.4.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
-    - install_chrome
     steps:
+      - install_chrome
       - checkout
       - <<: *restore_node_modules_cache
       - run: PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome npm run coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,22 @@
 version: 2
 
+orbs:
+  browser-tools: circleci/browser-tools@1.4.6
+
 defaults: &defaults
   docker:
-    - image: circleci/node:14-browsers
+    - image: circleci/node:20-browsers
   working_directory: ~/puppeteer-devtools
+
+commands:
+  install_chrome:
+    steps:
+      - browser-tools/install-browser-tools:
+          chrome-version: << parameters.chrome-version >>
+      - run:
+          command: |
+            google-chrome --version
+          name: Google Chrome Version
 
 npm_cache_key: &npm_cache_key
   v2-node-modules-cache-{{ checksum "package-lock.json" }}
@@ -36,6 +49,7 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
+    - install_chrome
     steps:
       - checkout
       - <<: *restore_node_modules_cache
@@ -69,6 +83,9 @@ workflows:
     jobs:
       - dependencies
       - test:
+          matrix:
+            parameters:
+              chrome-version: ["latest", "102.0.5002.0"]
           requires:
             - dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
+    parameters:
+      chrome-version:
+        type: string
     steps:
       - install_chrome
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,12 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
+    parameters:
+      chrome-version:
+        type: string
     steps:
       - install_chrome
+          chrome-version: << parameters.chrome-version >>
       - checkout
       - <<: *restore_node_modules_cache
       - run: PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome npm run coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           name: "test-chrome-<< matrix.chrome-version >>"
           matrix:
             parameters:
-              chrome-version: ["latest", "119.0.6045.159"]
+              chrome-version: ["latest", "102.0.5005.61"]
           requires:
             - dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/node:20.10-browsers
+    - image: cimg/node:20-browsers
   working_directory: ~/puppeteer-devtools
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
         type: string
         default: "latest"
     steps:
+      - run: sudo apt-get update
       - browser-tools/install-chrome:
           chrome-version: << parameters.chrome-version >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/node:20-browsers
+    - image: circleci/node:20.10-browsers
   working_directory: ~/puppeteer-devtools
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              chrome-version: ["latest", "102.0.5002.0"]
+              chrome-version: ["latest", "102.0.5005.61"]
           requires:
             - dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ defaults: &defaults
 
 commands:
   install_chrome:
+    parameters:
+      chrome-version:
+        type: string
+        default: "latest"
     steps:
       - browser-tools/install-browser-tools:
           chrome-version: << parameters.chrome-version >>
@@ -49,9 +53,6 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
-    parameters:
-      chrome-version:
-        type: string
     steps:
       - install_chrome
       - checkout
@@ -81,7 +82,6 @@ jobs:
       - run: npm publish
 
 workflows:
-  version: 2
   build:
     jobs:
       - dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       chrome-version:
         type: string
     steps:
-      - install_chrome
+      - install_chrome:
           chrome-version: << parameters.chrome-version >>
       - checkout
       - <<: *restore_node_modules_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,10 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
-    parameters:
-      chrome-version:
-        type: string
+    name: "test-chrome-<< matrix.chrome-version >>"
     steps:
       - install_chrome:
-          chrome-version: << parameters.chrome-version >>
+          chrome-version: << matrix.chrome-version >>
       - checkout
       - <<: *restore_node_modules_cache
       - run: PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome npm run coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: cimg/node:20-browsers
+    - image: cimg/node:20.10-browsers
   working_directory: ~/puppeteer-devtools
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           name: "test-chrome-<< matrix.chrome-version >>"
           matrix:
             parameters:
-              chrome-version: ["latest", "102.0.5005.61"]
+              chrome-version: ["latest", "110.0.5481.77"]
           requires:
             - dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
-    name: "test-chrome-<< matrix.chrome-version >>"
     steps:
       - install_chrome:
           chrome-version: << matrix.chrome-version >>
@@ -85,6 +84,7 @@ workflows:
     jobs:
       - dependencies
       - test:
+          name: "test-chrome-<< matrix.chrome-version >>"
           matrix:
             parameters:
               chrome-version: ["latest", "102.0.5005.61"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          command: |
-            google-chrome --version
       - <<: *restore_node_modules_cache
       # Skip the bundled version of chrome; always use the one provided from circle
       - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,12 @@ jobs:
           key: *npm_cache_key
   test:
     <<: *defaults
+    parameters:
+      chrome-version:
+        type: string
     steps:
       - install_chrome:
-          chrome-version: << matrix.chrome-version >>
+          chrome-version: << parameters.chrome-version >>
       - checkout
       - <<: *restore_node_modules_cache
       - run: PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome npm run coverage

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,21 +125,20 @@ async function getDevtoolsPanel(
     `,
       { timeout }
     )
+    const extensionPanelView = await devtools.evaluate(
+      `
+      Object.keys(UI.panels)
+        .find(key => key.startsWith('${extensionUrl}'))
+    `,
+      { timeout }
+    )
 
     switch(strategy) {
       case 'ui-viewmanager':
-        await devtools.evaluate(`
-          const extensionPanelView = Object.keys(UI.panels)
-            .find(key => key.startsWith('${extensionUrl}'));
-          UI.viewManager.showView(extensionPanelView);
-        `)
+        await devtools.evaluate(`UI.viewManager.showView('${extensionPanelView}')`)
       break;
       case 'inspectorfrontendapi':
-        await devtools.evaluate(`
-          const extensionPanelView = Object.keys(UI.panels)
-            .find(key => key.startsWith('${extensionUrl}'));
-          InspectorFrontendAPI.showPanel(extensionPanelView);
-        `)
+        await devtools.evaluate(`InspectorFrontendAPI.showPanel('${extensionPanelView}')`)
       break;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,9 +140,10 @@ async function getDevtoolsPanel(
       case 'inspectorfrontendapi':
         await devtools.evaluate(`InspectorFrontendAPI.showPanel('${extensionPanelView}')`)
       break;
-      default:
+      default: {
         const unknownStrategy: never = strategy;
         throw new Error(`Unknown strategy: ${unknownStrategy}`);
+      }
     }
 
     extensionPanelTarget = await browser.waitForTarget(

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ async function getBackground(
 // - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/legacy/ViewManager.ts
 // - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/devtools_compatibility.js
 const devtoolsViewManagementStrategies = [
-  { strategy: 'ui-viewmanager', func: `!!('UI' in window && 'viewManager' in UI && 'showView' in UI.viewManger)` },
+  { strategy: 'ui-viewmanager', func: `!!('UI' in window && 'viewManager' in UI && 'showView' in UI?.viewManger)` },
   { strategy: 'inspectorfrontendapi', func: `!!('InspectorFrontendAPI' in window && 'showPanel' in InspectorFrontendAPI)`}
 ] as const
 type DevtoolsViewManagementStrategies = typeof devtoolsViewManagementStrategies[number]['strategy']

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ async function getDevtoolsPanel(
       ])
     } catch (err) {
       if (!(err instanceof errors.TimeoutError)) {
+        /* istanbul ignore next */
         throw err
       }
     }
@@ -140,6 +141,7 @@ async function getDevtoolsPanel(
       case 'inspectorfrontendapi':
         await devtools.evaluate(`InspectorFrontendAPI.showPanel('${extensionPanelView}')`)
       break;
+      /* istanbul ignore next */
       default: {
         const unknownStrategy: never = strategy;
         throw new Error(`Unknown strategy: ${unknownStrategy}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,9 @@ async function getDevtoolsPanel(
       case 'inspectorfrontendapi':
         await devtools.evaluate(`InspectorFrontendAPI.showPanel('${extensionPanelView}')`)
       break;
+      default:
+        const unknownStrategy: never = strategy;
+        throw new Error(`Unknown strategy: ${unknownStrategy}`);
     }
 
     extensionPanelTarget = await browser.waitForTarget(

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,27 +73,51 @@ async function getBackground(
   return getContext(page, isBackground, options)
 }
 
+// Chrome has different methodologies for view management depending on the version,
+// we need to determine the right strategy for what's available in the current chrome executable
+// reference links: 
+// - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/legacy/ViewManager.ts
+// - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/devtools_compatibility.js
+const devtoolsViewManagementStrategies = [
+  { strategy: 'ui-viewmanager', func: `!!('UI' in window && 'viewManager' in UI && 'showView' in UI.viewManger)` },
+  { strategy: 'inspectorfrontendapi', func: `!!('InspectorFrontendAPI' in window && 'showPanel' in InspectorFrontendAPI)`}
+] as const
+type DevtoolsViewManagementStrategies = typeof devtoolsViewManagementStrategies[number]['strategy']
+
 async function getDevtoolsPanel(
   page: Page,
   options?: { panelName?: string; timeout?: number }
 ): Promise<Frame> {
   const browser = page.browser()
-  const { panelName = 'panel.html', timeout } = options || {}
+  const { panelName = 'panel.html', timeout = 30000 } = options || {}
 
   const devtools = await getDevtools(page)
 
   let extensionPanelTarget: Target
 
   try {
-    // Wait for UI.viewManager to become available
-    await devtools.waitForFunction(
-      /* istanbul ignore next */
-      () => 'UI' in window && 'viewManager' in (window as any).UI,
-      { timeout }
-    )
+    // Wait for one of the view management strategies to be available
+    let strategy: DevtoolsViewManagementStrategies | void = undefined
+    try {
+      strategy = await Promise.race<DevtoolsViewManagementStrategies | void>([
+        ...devtoolsViewManagementStrategies.map(async ({ strategy, func }) => {
+          await devtools.waitForFunction(func, { timeout })
+          return strategy
+        })
+      ])
+    } catch (err) {
+      if (!(err instanceof errors.TimeoutError)) {
+        throw err
+      }
+    }
 
-    // Check that the UI.viewManager has a chrome-extension target available
+    if (!strategy) {
+      throw new Error(`[${await page.browser().version()}] Unable to find view manager for browser executable.`)
+    }
+
+    // Check that there is an available chrome-extension panel target
     // source: https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/legacy/ViewManager.ts
+    await devtools.waitForFunction(`!!('UI' in window && 'panels' in UI)`, { timeout })
     await devtools.waitForFunction(
       `
       !!Object.keys(UI.panels)
@@ -102,12 +126,22 @@ async function getDevtoolsPanel(
       { timeout }
     )
 
-    // Once available, swap to the bundled chrome-extension devtools view
-    await devtools.evaluate(`
-      const extensionPanelView = Object.keys(UI.panels)
-        .find(key => key.startsWith('${extensionUrl}'))
-      UI.viewManager.showView(extensionPanelView);
-    `)
+    switch(strategy) {
+      case 'ui-viewmanager':
+        await devtools.evaluate(`
+          const extensionPanelView = Object.keys(UI.panels)
+            .find(key => key.startsWith('${extensionUrl}'));
+          UI.viewManager.showView(extensionPanelView);
+        `)
+      break;
+      case 'inspectorfrontendapi':
+        await devtools.evaluate(`
+          const extensionPanelView = Object.keys(UI.panels)
+            .find(key => key.startsWith('${extensionUrl}'));
+          InspectorFrontendAPI.showPanel(extensionPanelView);
+        `)
+      break;
+    }
 
     extensionPanelTarget = await browser.waitForTarget(
       target => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ async function getBackground(
 // - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/legacy/ViewManager.ts
 // - https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/devtools_compatibility.js
 const devtoolsViewManagementStrategies = [
-  { strategy: 'ui-viewmanager', func: `!!('UI' in window && 'viewManager' in UI && 'showView' in UI?.viewManger)` },
-  { strategy: 'inspectorfrontendapi', func: `!!('InspectorFrontendAPI' in window && 'showPanel' in InspectorFrontendAPI)`}
+  { strategy: 'ui-viewmanager', func: `!!('UI' in window && 'viewManager' in UI && typeof UI.viewManager.showPanel === 'function')` },
+  { strategy: 'inspectorfrontendapi', func: `!!('InspectorFrontendAPI' in window && 'showPanel' in InspectorFrontendAPI && typeof InspectorFrontendAPI.showPanel === 'function')`}
 ] as const
 type DevtoolsViewManagementStrategies = typeof devtoolsViewManagementStrategies[number]['strategy']
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -93,6 +93,18 @@ test('should return devtools panel', async t => {
   t.is(textContent?.trim(), 'devtools panel')
 })
 
+test('should throw with no matching strategies for showing devtools panel', async t => {
+  const { page } = t.context
+  const devtools = await getDevtools(page)
+  // remove known chrome public apis to force errors
+  await devtools.evaluate(`
+    delete window.UI
+    delete window.InspectorFrontendAPI
+  `)
+  const error = await t.throwsAsync(getDevtoolsPanel(page, { timeout: 100 }))
+  t.regex(error.message, /Unable to find view manager for browser executable/)
+})
+
 test('should return extension content script execution context', async t => {
   const { page } = t.context
   await setCaptureContentScriptExecutionContexts(page)


### PR DESCRIPTION
Sometime after Chrome 119, `UI.ViewManager` appears to no longer be available. I'm attempting to maintain backwards compatibility by checking for `InspectorFrontendAPI`, which seems to provide the same functionality.