### PR TITLE
Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
           name: "test-chrome-<< matrix.chrome-version >>"
           matrix:
             parameters:
-              chrome-version: ["latest", "110.0.5481.77"]
+              chrome-version: ["latest", "111.0.5563.146"]
           requires:
             - dependencies
       - lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.3.0](https://github.com/dequelabs/puppeteer-devtools/compare/v3.2.0...v3.3.0) (2024-04-04)
+
+
+### Features
+
+* add support for manifest v3 extensions and background service workers ([#81](https://github.com/dequelabs/puppeteer-devtools/issues/81)) ([0608018](https://github.com/dequelabs/puppeteer-devtools/commit/06080187a19c13bc664eeff71074ae2084cc673c))
+
 ## [3.2.0](https://github.com/dequelabs/puppeteer-devtools/compare/v3.1.0...v3.2.0) (2024-02-05)
 
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ const contentScriptExecutionContext = await getContentScriptExecutionContext(
 
 Note: `devtools` must be enabled, and `headless` mode must be turned off. Chrome [does not currently support extensions in headless mode](https://bugs.chromium.org/p/chromium/issues/detail?id=706008).
 
+### Using a different browser executable
+
+`puppeteer-devtools` currently is [limited to versions of puppeteer &lt; `16.1.0`](https://github.com/dequelabs/puppeteer-devtools/issues/67#issuecomment-1629700824), meaning that in order to use versions of Chrome that are newer than the packaged version, you must use some variation of executable path:
+
+#### `browser.launch`
+
+```ts
+await puppeteer.launch({
+  ...options,
+  executablePath: '/path/to/chrome'
+})
+```
+
+#### Env Var
+
+```sh
+PUPPETEER_EXECUTABLE_PATH=/path/to/chrome npm run tests
+```
+
 ## Methods
 
 ### `async getDevtools( page, options? )`
@@ -90,4 +109,4 @@ If `setCaptureContentScriptExecutionContexts` has been enabled for a page, this 
 
 ## Copyright
 
-Copyright (c) 2019-2021 Deque Systems, Inc.
+Copyright (c) 2019-2024 Deque Systems, Inc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "puppeteer-devtools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "puppeteer-devtools",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@babel/cli": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer-devtools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Extended puppeteer methods for getting extension devtools contexts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * distribute or in any file that contains substantial portions of this source
  * code.
  */
-import { Page, Frame, Target, errors } from 'puppeteer'
+import { Page, WebWorker, Frame, Target, errors } from 'puppeteer'
 import {
   DOMWorld,
   ExecutionContext,
@@ -19,6 +19,10 @@ import {
 
 const devtoolsUrl = 'devtools://'
 const extensionUrl = 'chrome-extension://'
+const types = {
+  page: 'page',
+  serviceWorker: 'service_worker'
+}
 
 const isDevtools = (target: Target) => {
   return target.url().startsWith(devtoolsUrl)
@@ -26,50 +30,79 @@ const isDevtools = (target: Target) => {
 const isBackground = (target: Target) => {
   const url = target.url()
   return (
-    url.startsWith(extensionUrl) && url.includes('generated_background_page')
+    url.startsWith(extensionUrl) && (url.includes('generated_background_page') || target.type() === types.serviceWorker)
   )
+}
+const isPage = (target: Page | WebWorker): target is Page => {
+  // When $ exists, it's most likely a page...
+  return '$' in target && typeof target.$ === 'function'
 }
 
 async function getContext(
   page: Page,
   isTarget: (t: Target) => boolean,
   options?: { timeout?: number }
-): Promise<Page> {
+): Promise<Page | WebWorker> {
   const browser = page.browser()
   const { timeout } = options || {}
 
   const target = await browser.waitForTarget(isTarget, { timeout })
+  const type = target.type()
+  const url = target.url()
 
-  // Hack to get puppeteer to allow us to access the page context
-  ;(target as any)._targetInfo.type = 'page'
+  if (type === types.serviceWorker) {
+    const worker = await target.worker()
+    if (!worker) {
+      /* istanbul ignore next */
+      throw new Error(`Could not convert "${url}" target to a worker.`)
+    }
 
-  const contextPage = await target.page()
+    return worker
+  } else {
+    let contextPage: Page | null
 
-  if (!contextPage) {
     /* istanbul ignore next */
-    throw new Error(`Could not convert "${extensionUrl}" target to a page.`)
+    if ('asPage' in target && typeof target.asPage === 'function') {
+      contextPage = await target.asPage()
+    } else {
+      // Hack to get puppeteer to allow us to access the page context
+      ;(target as any)._targetInfo.type = types.page
+      contextPage = await target.page()
+    }
+
+    if (!contextPage) {
+      /* istanbul ignore next */
+      throw new Error(`Could not convert "${url}" target to a page.`)
+    }
+
+    await contextPage.waitForFunction(
+      /* istanbul ignore next */
+      () => document.readyState === 'complete',
+      { timeout }
+    )
+
+    return contextPage
   }
-
-  await contextPage.waitForFunction(
-    /* istanbul ignore next */
-    () => document.readyState === 'complete',
-    { timeout }
-  )
-
-  return contextPage
 }
 
 async function getDevtools(
   page: Page,
   options?: { timeout?: number }
 ): Promise<Page> {
-  return getContext(page, isDevtools, options)
+  const context = await getContext(page, isDevtools, options)
+
+  if (!isPage(context)) {
+    /* istanbul ignore next */
+    throw new Error(`Devtools target "${page.url()}" is not of type page.`)
+  }
+
+  return context
 }
 
 async function getBackground(
   page: Page,
   options?: { timeout?: number }
-): Promise<Page> {
+): Promise<Page | WebWorker> {
   return getContext(page, isBackground, options)
 }
 
@@ -134,6 +167,7 @@ async function getDevtoolsPanel(
       { timeout }
     )
 
+    /* istanbul ignore next */
     switch(strategy) {
       case 'ui-viewmanager':
         await devtools.evaluate(`UI.viewManager.showView('${extensionPanelView}')`)
@@ -167,15 +201,19 @@ async function getDevtoolsPanel(
     throw err
   }
 
-  // Hack to get puppeteer to allow us to access the page context
-  ;(extensionPanelTarget as any)._targetInfo.type = 'page'
-
-  // Get the targeted target's page and frame
-  const panel = await extensionPanelTarget.page()
+  let panel: Page | null
+  /* istanbul ignore next */
+  if ('asPage' in extensionPanelTarget && typeof extensionPanelTarget.asPage === 'function') {
+    panel = await extensionPanelTarget.asPage()
+  } else {
+    // Hack to get puppeteer to allow us to access the page context
+    ;(extensionPanelTarget as any)._targetInfo.type = types.page
+    panel = await extensionPanelTarget.page()
+  }
 
   if (!panel) {
     /* istanbul ignore next */
-    throw new Error(`Could not convert "${extensionUrl}" target to a page.`)
+    throw new Error(`Could not convert "${extensionPanelTarget.url()}" target to a page.`)
   }
 
   // The extension panel should be the first embedded frame of the targeted page

--- a/test/extension-manifest-v3/background.js
+++ b/test/extension-manifest-v3/background.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var foo

--- a/test/extension-manifest-v3/content.js
+++ b/test/extension-manifest-v3/content.js
@@ -1,0 +1,3 @@
+(() => {
+  window.extension_content_script = true;
+})()

--- a/test/extension-manifest-v3/devtools.html
+++ b/test/extension-manifest-v3/devtools.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>devtools page</title>
+    <script src="devtools.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/extension-manifest-v3/devtools.js
+++ b/test/extension-manifest-v3/devtools.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+chrome.devtools.panels.create('test extension', '', 'panel.html', ()=> {})

--- a/test/extension-manifest-v3/manifest.json
+++ b/test/extension-manifest-v3/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "Test Chrome Extension Manifest V3",
+  "description": "Test Chrome Extension Manifest V3",
+  "version": "1.2.3",
+  "devtools_page": "devtools.html",
+  "content_scripts": [
+    {
+      "matches": ["*://testpage.test/", "*://testpage.test/frame"],
+      "js": ["content.js"],
+      "all_frames": true,
+      "run_at": "document_start"
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' ; object-src 'self'"
+  },
+  "web_accessible_resources": [{
+    "resources": ["page.html"],
+    "matches": ["<all_urls>"]
+  }]
+}

--- a/test/extension-manifest-v3/page.html
+++ b/test/extension-manifest-v3/page.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>extension page</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/extension-manifest-v3/panel.html
+++ b/test/extension-manifest-v3/panel.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      body {
+        background-color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div>devtools panel</div>
+  </body>
+</html>

--- a/test/test-manifest-v3.ts
+++ b/test/test-manifest-v3.ts
@@ -12,7 +12,7 @@ import {
 
 beforeEach(async function () {
   try {
-    const pathToExtension = path.resolve(__dirname, 'extension')
+    const pathToExtension = path.resolve(__dirname, 'extension-manifest-v3')
 
     const browser = await puppeteer.launch({
       args: [
@@ -52,7 +52,7 @@ beforeEach(async function () {
       return request.continue()
     })
 
-    this.context = {
+    this.manifestV3context = {
       browser,
       page
     }
@@ -62,29 +62,29 @@ beforeEach(async function () {
 })
 
 afterEach(async function() {
-  const { browser } = this.context
+  const { browser } = this.manifestV3context
   if (browser) {
     await browser.close()
   }
-  this.context = null
+  this.manifestV3context = null
 })
 
-describe('puppeteer-devtools', () => {
+describe('puppeteer-devtools (manifest v3)', () => {
 
   it('should return devtools page', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     const devtools = await getDevtools(page)
     assert.match(await devtools.url(), /^devtools:\/\//)
   })
 
   it('should return background page', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     const background = await getBackground(page)
-    assert.match(await background?.url(), /_generated_background_page/)
+    assert.match(await background?.url(), /background.js$/)
   })
 
   it('should return devtools panel', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     const devtools = await getDevtoolsPanel(page)
     const body = await devtools.$('body')
     const textContent = await devtools.evaluate(el => el?.textContent, body)
@@ -92,7 +92,7 @@ describe('puppeteer-devtools', () => {
   })
 
   it('should throw with no matching strategies for showing devtools panel', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     const devtools = await getDevtools(page)
     // remove known chrome public apis to force errors
     await devtools.evaluate(`
@@ -106,7 +106,7 @@ describe('puppeteer-devtools', () => {
   })
 
   it('should return extension content script execution context', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     await setCaptureContentScriptExecutionContexts(page)
     await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
     const contentExecutionContext = await getContentScriptExcecutionContext(page)
@@ -121,13 +121,13 @@ describe('puppeteer-devtools', () => {
   })
 
   it('should throw error when unable to find content script execution context', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     await page.goto('http://testpage.test', { waitUntil: 'networkidle2' })
     assert.rejects(async () => await getContentScriptExcecutionContext(page))
   })
 
   it('should throw error when unable to find content script execution context on page without permissions', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     await setCaptureContentScriptExecutionContexts(page)
     await page.goto('http://testpage.test/that/does/not/have/permission', {
       waitUntil: 'networkidle2'
@@ -136,7 +136,7 @@ describe('puppeteer-devtools', () => {
   })
 
   it('should throw error when unable to find devtools panel', async function() {
-    const { page } = this.context
+    const { page } = this.manifestV3context
     assert.rejects(async () =>
       getDevtoolsPanel(page, { panelName: 'foo.html', timeout: 500 })
     )


### PR DESCRIPTION
## [3.3.0](https://github.com/dequelabs/puppeteer-devtools/compare/v3.2.0...v3.3.0) (2024-04-04)


### Features

* add support for manifest v3 extensions and background service workers ([#81](https://github.com/dequelabs/puppeteer-devtools/issues/81)) ([0608018](https://github.com/dequelabs/puppeteer-devtools/commit/06080187a19c13bc664eeff71074ae2084cc673c))